### PR TITLE
Reject formation entries without a process declaration

### DIFF
--- a/lib/app_manifest.rb
+++ b/lib/app_manifest.rb
@@ -56,8 +56,10 @@ module AppManifest
       canonicalize_key(manifest, :formation) do |formation|
         if formation.is_a? Array
           Hash[
-            formation.map do |entry|
-              process = entry[:process]
+            formation
+            .reject { |entry| entry[:process].to_s.empty? }
+            .map do |entry|
+              process = entry.fetch(:process)
               entry = entry.reject { |k, _| k == :process }
               [process.to_sym, entry]
             end

--- a/test/app_manifest_test.rb
+++ b/test/app_manifest_test.rb
@@ -55,4 +55,11 @@ class AppManifestTest < Minitest::Test
     canonicalized = AppManifest.canonicalize('env' => { 'foo' => 'bar' })
     assert_equal(canonicalized, env: { 'foo' => { value: 'bar' } })
   end
+
+  def test_canonicalize__formation_missing_process
+    canonicalized = AppManifest.canonicalize(
+      'formation' => [{ 'quantity' => 1 }]
+    )
+    assert_equal(canonicalized, formation: {})
+  end
 end


### PR DESCRIPTION
This fixes a no method error when a legacy formation entry is missing the process type.