### PR TITLE
Bug fix grab bag

### DIFF
--- a/lib/app_manifest.rb
+++ b/lib/app_manifest.rb
@@ -57,6 +57,7 @@ module AppManifest
         if formation.is_a? Array
           Hash[
             formation
+            .map { |entry| keys_to_sym(entry) }
             .reject { |entry| entry[:process].to_s.empty? }
             .map do |entry|
               process = entry.fetch(:process)

--- a/lib/app_manifest.rb
+++ b/lib/app_manifest.rb
@@ -83,7 +83,7 @@ module AppManifest
               plan: entry,
             }
           else
-            entry
+            keys_to_sym(entry)
           end
         end
       end

--- a/test/app_manifest_test.rb
+++ b/test/app_manifest_test.rb
@@ -67,6 +67,25 @@ class AppManifestTest < Minitest::Test
     assert_equal(canonicalized, env: { 'foo' => { value: 'bar' } })
   end
 
+  def test_canonicalize__deep_symbolize_addons
+    canonicalized = AppManifest.canonicalize(
+      'addons' => [{
+        'plan' => 'heroku-postgres:hobby-dev',
+        'options' => {
+          'version' => '9.2'
+        }
+      }]
+    )
+    assert_equal(canonicalized,
+      addons: [{
+        plan: 'heroku-postgres:hobby-dev',
+        options: {
+          version: '9.2'
+        }
+      }]
+    )
+  end
+
   def test_canonicalize__formation_missing_process
     canonicalized = AppManifest.canonicalize(
       'formation' => [{ 'quantity' => 1 }]

--- a/test/app_manifest_test.rb
+++ b/test/app_manifest_test.rb
@@ -86,6 +86,39 @@ class AppManifestTest < Minitest::Test
     )
   end
 
+  def test_canonicalize__deep_symbolize_formation
+    canonicalized = AppManifest.canonicalize(
+      'formation' => {
+        'web' => {
+          'quantity' => 1
+        }
+      }
+    )
+    assert_equal(canonicalized,
+      formation: {
+        web:{
+          quantity: 1
+        }
+      }
+    )
+  end
+
+  def test_canonicalize__deep_symbolize_legacy_formation
+    canonicalized = AppManifest.canonicalize(
+      'formation' => [{
+        'process' => 'web',
+        'quantity' => 1
+      }]
+    )
+    assert_equal(canonicalized,
+      formation: {
+        web:{
+          quantity: 1
+        }
+      }
+    )
+  end
+
   def test_canonicalize__formation_missing_process
     canonicalized = AppManifest.canonicalize(
       'formation' => [{ 'quantity' => 1 }]


### PR DESCRIPTION
This fixes the following issues:

1. The addons has was not being symbolized, this would result in something looking like `{ addons: { "plan" => "heroku-postgresql"} }` which is hard to reason about. Everything is now returned as a symbol.
2. Legacy formation handling didn't work correctly when the keys were strings.