### PR TITLE
Handle non-string and non-hash values

### DIFF
--- a/lib/app_manifest.rb
+++ b/lib/app_manifest.rb
@@ -36,9 +36,9 @@ module AppManifest
       canonicalize_key(manifest, :env) do |env|
         Hash[
           env.map do |key, value|
-            if value.is_a? String
+            if !value.is_a?(Hash)
               value = {
-                value: value,
+                value: value.to_s,
               }
             end
             [key.to_s, value]

--- a/test/app_manifest/manifest_test.rb
+++ b/test/app_manifest/manifest_test.rb
@@ -7,9 +7,9 @@ class AppManifest::ManifestTest < MiniTest::Test
   end
 
   def test_initialize__canonicalizes_hash
-    manifest = AppManifest::Manifest.new(env: { 'BAR' => 'BAZ' })
+    manifest = AppManifest::Manifest.new(env: { 'BAR' => 'BAZ', 'FOO' => true })
     env = manifest.to_hash.fetch(:env)
-    assert_equal(env, 'BAR' => { value: 'BAZ' })
+    assert_equal(env, 'BAR' => { value: 'BAZ' }, 'FOO' => { value: 'true' })
   end
 
   def test_environment__when_present


### PR DESCRIPTION
A bool value is not a string. It also doesn't match as a hash.
So instead of checking for strings, we need to check for not-hash, and stringify everything.

cc @raulb 