### PR TITLE
Allow booleans as env values

### DIFF
--- a/lib/app_manifest.rb
+++ b/lib/app_manifest.rb
@@ -36,7 +36,7 @@ module AppManifest
       canonicalize_key(manifest, :env) do |env|
         Hash[
           env.map do |key, value|
-            if value.is_a? String
+            if value.is_a?(String) || [true, false].include?(value)
               value = {
                 value: value,
               }

--- a/test/app_manifest_test.rb
+++ b/test/app_manifest_test.rb
@@ -36,6 +36,11 @@ class AppManifestTest < Minitest::Test
     assert_equal(canonicalized, env: { 'foo' => { value: 'bar' } })
   end
 
+  def test_canonicalize__env_shorthand_boolean
+    canonicalized = AppManifest.canonicalize(env: { 'foo' => true })
+    assert_equal(canonicalized, env: { 'foo' => { value: true } })
+  end
+
   def test_canonicalize__legacy_formation
     manifest = { formation: [{ process: 'web', quantity: 5 }] }
     canonicalized = AppManifest.canonicalize(manifest)


### PR DESCRIPTION
Currently an env value like:

```
"env": {
  "MY_KEY": true
}
```

Does not get canoncialized the same as a string value. This is leading to errors in applications like `NoMethodError: undefined method `[]' for true:TrueClass` when the caller should be able to safely assume that an env key has been turned into a hash with a `value` key.