### PR TITLE
Support env shorthands with numeric values

### DIFF
--- a/lib/app_manifest.rb
+++ b/lib/app_manifest.rb
@@ -45,12 +45,14 @@ module AppManifest
       canonicalize_key(manifest, :env) do |env|
         Hash[
           env.map do |key, value|
-            if value.is_a?(String) || [true, false].include?(value)
-              value = {
-                value: value,
-              }
+            case value
+            when Hash
+              [key.to_s, value]
+            when String, TrueClass, FalseClass, Integer, Float
+              [key.to_s, { value: value }]
+            else
+              [key.to_s, value.to_s]
             end
-            [key.to_s, value]
           end
         ]
       end

--- a/test/app_manifest_test.rb
+++ b/test/app_manifest_test.rb
@@ -41,6 +41,11 @@ class AppManifestTest < Minitest::Test
     assert_equal(canonicalized, env: { 'foo' => { value: true } })
   end
 
+  def test_canonicalize__env_shorthand_integer
+    canonicalized = AppManifest.canonicalize(env: { 'bar' => 5 })
+    assert_equal(canonicalized, env: { 'bar' => { value: 5 } })
+  end
+
   def test_canonicalize__legacy_formation
     manifest = { formation: [{ process: 'web', quantity: 5 }] }
     canonicalized = AppManifest.canonicalize(manifest)


### PR DESCRIPTION
A manifest using env shorthands with numeric values gets canonicalized in a surprising way:

`env: { 'FOO' => 5 }` => `env: { 'FOO' => 5 }`

It might be more appropriate to say it doesn't get canonicalized at all. Consider that in most cases, the value is a string, and the canonicalization results in the predictable, long format:

`env: { 'FOO' => 'five' }` => `env: { 'FOO' => { value: 'five' } }`.

This PR fixes the inconsistency by correctly canonicalizing numeric types.
  