### PR TITLE
Add manifest validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 /spec/reports/
 /tmp/
 app_manifest-*.gem
+
+*.iml
+/.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [1.0.0] - 2021-11-08
+
+### Added
+- `AppManifest::ManifestValidator` module performs basic type checking validation for a given manifest hash.
+  The Error `AppManifest::InvalidManifest` is raised if the manifest is invalid.
+
+### Changed
+- `AppManifest` now uses `AppManifest::ManifestValidator` to validate the manifest hash by default.
+  The `validate` named parameter can be set to `false` to disable this.
+
 ## [0.5.0] - 2018-07-24
 
 ### Added

--- a/app_manifest.gemspec
+++ b/app_manifest.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_dependency "multi_json", "~> 1.0"
   spec.add_dependency "virtus", "~> 1.0"
 end

--- a/lib/app_manifest.rb
+++ b/lib/app_manifest.rb
@@ -13,11 +13,11 @@ require "app_manifest/environment"
 require "app_manifest/manifest"
 
 # Create a new manifest from json string or a hash
-def AppManifest(input)
+def AppManifest(input, validate: true)
   if input.is_a?(Hash)
-    AppManifest::Manifest.new(input)
+    AppManifest::Manifest.new(input, validate)
   elsif input.is_a?(String)
-    AppManifest::Manifest.from_json(input)
+    AppManifest::Manifest.from_json(input, validate)
   end
 end
 

--- a/lib/app_manifest.rb
+++ b/lib/app_manifest.rb
@@ -15,9 +15,9 @@ require "app_manifest/manifest"
 # Create a new manifest from json string or a hash
 def AppManifest(input, validate: true)
   if input.is_a?(Hash)
-    AppManifest::Manifest.new(input, validate)
+    AppManifest::Manifest.new(input, validate: validate)
   elsif input.is_a?(String)
-    AppManifest::Manifest.from_json(input, validate)
+    AppManifest::Manifest.from_json(input, validate: validate)
   end
 end
 

--- a/lib/app_manifest/manifest.rb
+++ b/lib/app_manifest/manifest.rb
@@ -1,3 +1,5 @@
+require "app_manifest/manifest_validator"
+
 module AppManifest
   # A simple model-like wrapper around a manifest hash.
   class Manifest
@@ -13,6 +15,7 @@ module AppManifest
     end
 
     def initialize(hash)
+      AppManifest::ManifestValidator.validate!(hash)
       canonicalized = AppManifest.canonicalize(hash)
       super(canonicalized)
     end

--- a/lib/app_manifest/manifest.rb
+++ b/lib/app_manifest/manifest.rb
@@ -14,8 +14,8 @@ module AppManifest
       new(hash)
     end
 
-    def initialize(hash)
-      AppManifest::ManifestValidator.validate!(hash)
+    def initialize(hash, validate: true)
+      AppManifest::ManifestValidator.validate!(hash) if validate
       canonicalized = AppManifest.canonicalize(hash)
       super(canonicalized)
     end

--- a/lib/app_manifest/manifest.rb
+++ b/lib/app_manifest/manifest.rb
@@ -9,9 +9,9 @@ module AppManifest
 
     attribute :environments, Hash[String => Environment], default: nil
 
-    def self.from_json(string)
+    def self.from_json(string, validate)
       hash = MultiJson.load(string)
-      new(hash)
+      new(hash, validate)
     end
 
     def initialize(hash, validate: true)

--- a/lib/app_manifest/manifest_validator.rb
+++ b/lib/app_manifest/manifest_validator.rb
@@ -97,6 +97,7 @@ module AppManifest
     end
 
     def self.validate_addon_hash(key_name, hash)
+      raise InvalidManifest, "Missing required key: plan" unless (hash.key?("plan") or hash.key?(:plan))
       hash.each do |key, value|
         case key.to_s
         when 'plan'

--- a/lib/app_manifest/manifest_validator.rb
+++ b/lib/app_manifest/manifest_validator.rb
@@ -90,7 +90,7 @@ module AppManifest
       when Hash
         validate_addon_hash(key_name, value)
       else
-        raise InvalidManifest, "Expected string or object #{for_key(key, index: index, env_name: env)} " \
+        raise InvalidManifest, "Expected string or object #{for_key(key, index: index, env_name: env_name)} " \
         "but got: #{value.class}"
       end
     end
@@ -120,7 +120,7 @@ module AppManifest
         end
       when nil
       else
-        raise InvalidManifest, "Expected object #{for_key(key, env_name: env)} but got: #{value.class}"
+        raise InvalidManifest, "Expected object #{for_key(key, env_name: env_name)} but got: #{value.class}"
       end
     end
 

--- a/lib/app_manifest/manifest_validator.rb
+++ b/lib/app_manifest/manifest_validator.rb
@@ -11,6 +11,7 @@ module AppManifest
     private
 
     def self.do_validate(hash, env_name: nil)
+      raise InvalidManifest, "Expected object but got: #{hash.class}" unless hash.is_a?(Hash)
       hash.each do |key, value|
         case key.to_s
         when 'addons'
@@ -41,10 +42,10 @@ module AppManifest
     def self.build_key_name(key, index: nil, env_name: nil)
       name = []
       name << env_name if env_name
-      name << '[' if env_name
+      name << '[' unless env_name.nil?
       name << key
-      name << ']' if env_name
-      name << "[#{index}]" if index
+      name << ']' unless env_name.nil?
+      name << "[#{index}]" unless index.nil?
       name.join
     end
 

--- a/lib/app_manifest/manifest_validator.rb
+++ b/lib/app_manifest/manifest_validator.rb
@@ -20,21 +20,14 @@ module AppManifest
           end
         when 'buildpacks'
           validate_array(key, value, required: false, env_name: env_name)
+        when 'name', 'description', 'image', 'logo', 'repository', 'stack', 'success_url', 'website'
+          validate_string(key, value, required: false, env_name: env_name)
         when 'env'
           validate_env(key, value, env_name: env_name)
-        when 'name'
-          validate_string(key, value, required: false, max_length: 30, env_name: env_name)
-        when 'description', 'image', 'logo', 'repository', 'stack', 'success_url', 'website'
-          validate_string(key, value, required: false, env_name: env_name)
         when 'environments'
           validate_environments(key, value) if env_name.nil?
         when 'keywords'
-          validate_array(key, value, required: false, env_name: env_name) do |v, index: nil, env_name: nil|
-            validate_string(key, v, required: false, index: index, env_name: env_name)
-          end
-        when 'scripts', 'formation'
-        else
-          raise InvalidManifest, "Unknown key: #{build_key_name(key, env_name: env_name)}"
+          validate_array(key, value, required: false, env_name: env_name)
         end
       end
     end
@@ -68,14 +61,11 @@ module AppManifest
       end
     end
 
-    def self.validate_string(key, value, required: true, max_length: nil, index: nil, env_name: nil)
+    def self.validate_string(key, value, required: true, index: nil, env_name: nil)
       k = for_key(key, index: index, env_name: env_name)
       case value
       when String
         raise InvalidManifest, "String must not be empty #{k}" if required && value.empty?
-        if max_length && value.length > max_length
-          raise InvalidManifest, "String must not exceed #{max_length} characters #{k}"
-        end
       when nil
         raise InvalidManifest, "Missing required value #{k}" if required
       else

--- a/lib/app_manifest/manifest_validator.rb
+++ b/lib/app_manifest/manifest_validator.rb
@@ -1,0 +1,140 @@
+module AppManifest
+  class InvalidManifest < StandardError; end
+
+  # app.json manifest validation
+  module ManifestValidator
+
+    def self.validate!(manifest)
+      do_validate(manifest)
+    end
+
+    private
+
+    def self.do_validate(hash, env_name: nil)
+      hash.each do |key, value|
+        case key.to_s
+        when 'addons'
+          validate_array(key, value, required: false, env_name: env_name) do |v, index: nil, env_name: nil|
+            validate_addon_value(key, v, index: index, env_name: env_name)
+          end
+        when 'buildpacks'
+          validate_array(key, value, required: false, env_name: env_name)
+        when 'env'
+          validate_env(key, value, env_name: env_name)
+        when 'name'
+          validate_string(key, value, required: false, max_length: 30, env_name: env_name)
+        when 'description', 'image', 'logo', 'repository', 'stack', 'success_url', 'website'
+          validate_string(key, value, required: false, env_name: env_name)
+        when 'environments'
+          validate_environments(key, value) if env_name.nil?
+        when 'keywords'
+          validate_array(key, value, required: false, env_name: env_name) do |v, index: nil, env_name: nil|
+            validate_string(key, v, required: false, index: index, env_name: env_name)
+          end
+        when 'scripts', 'formation'
+        else
+          raise InvalidManifest, "Unknown key: #{build_key_name(key, env_name: env_name)}"
+        end
+      end
+    end
+
+    def self.build_key_name(key, index: nil, env_name: nil)
+      name = []
+      name << env_name if env_name
+      name << '[' if env_name
+      name << key
+      name << ']' if env_name
+      name << "[#{index}]" if index
+      name.join
+    end
+
+    def self.for_key(key, index: nil, env_name: nil)
+      "for key: #{build_key_name(key, index: index, env_name: env_name)}"
+    end
+
+    def self.validate_array(key, value, required: false, env_name: nil, &block)
+      case value
+      when Array
+        if block_given?
+          value.each_with_index do |v, i|
+            block.call(v, index: i, env_name: env_name)
+          end
+        end
+      when nil
+        raise InvalidManifest, "Missing required key: #{build_key_name(key, env_name: env_name)}" if required
+      else
+        raise InvalidManifest, "Expected array #{for_key(key, env_name: env_name)} but got: #{value.class}"
+      end
+    end
+
+    def self.validate_string(key, value, required: true, max_length: nil, index: nil, env_name: nil)
+      k = for_key(key, index: index, env_name: env_name)
+      case value
+      when String
+        raise InvalidManifest, "String must not be empty #{k}" if required && value.empty?
+        if max_length && value.length > max_length
+          raise InvalidManifest, "String must not exceed #{max_length} characters #{k}"
+        end
+      when nil
+        raise InvalidManifest, "Missing required value #{k}" if required
+      else
+        raise InvalidManifest, "Invalid value type: #{value.class} #{k}"
+      end
+    end
+
+    def self.validate_addon_value(key, value, index: nil, env_name: nil)
+      key_name = build_key_name(key, index: index, env_name: env_name)
+      case value
+      when String
+        validate_string(key, value, required: true, index: index, env_name: env_name)
+      when Hash
+        validate_addon_hash(key_name, value)
+      else
+        raise InvalidManifest, "Expected string or object #{for_key(key, index: index, env_name: env)} " \
+        "but got: #{value.class}"
+      end
+    end
+
+    def self.validate_addon_hash(key_name, hash)
+      hash.each do |key, value|
+        case key.to_s
+        when 'plan'
+          validate_string(key, value, required: true, env_name: key_name)
+        when 'as'
+          validate_string(key, value, required: false, env_name: key_name)
+        when 'options'
+          unless value.is_a?(Hash)
+            raise InvalidManifest, "Expected object #{for_key(key, env_name: key_name)} but got: #{value.class}"
+          end
+        else
+          raise InvalidManifest, "Unknown key: #{build_key_name(key, env_name: key_name)}"
+        end
+      end
+    end
+
+    def self.validate_env(key, value, env_name: nil)
+      case value
+      when Hash
+        value.each do |k, v|
+          validate_string(key, k, env_name: env_name)
+        end
+      when nil
+      else
+        raise InvalidManifest, "Expected object #{for_key(key, env_name: env)} but got: #{value.class}"
+      end
+    end
+
+    def self.validate_environments(key, value)
+      case value
+      when Hash
+        value.each do |env_name, env_value|
+          (%w[test review].include? env_name.to_s) || raise(InvalidManifest, "Invalid environment name: #{env_name}")
+          do_validate(env_value, env_name: "#{key}[#{env_name}]")
+        end
+      when nil
+      else
+        raise InvalidManifest, "Expected object for key environments but got: #{value.class}"
+      end
+    end
+  end
+end

--- a/lib/app_manifest/version.rb
+++ b/lib/app_manifest/version.rb
@@ -1,3 +1,3 @@
 module AppManifest
-  VERSION = '0.5.0'.freeze
+  VERSION = '1.0.0'.freeze
 end

--- a/test/app_manifest/manifest_validator_test.rb
+++ b/test/app_manifest/manifest_validator_test.rb
@@ -83,6 +83,23 @@ module AppManifest
       end
     end
 
+    def test_validate_name__max_length_valid
+      hash = valid_manifest_hash
+      hash["name"] = "a" * 30
+      assert_silent do
+        ManifestValidator.validate!(hash)
+      end
+    end
+
+    def test_validate_name__max_length_exceeded
+      hash = valid_manifest_hash
+      hash["name"] = "a" * 31
+      error = assert_raises(AppManifest::InvalidManifest) do
+        ManifestValidator.validate!(hash)
+      end
+      assert_match(/String must not exceed 30 characters for key: name/i, error.message)
+    end
+
     def test_validate_environment_manifest__valid
       hash = {
         "environments" => {
@@ -129,6 +146,41 @@ module AppManifest
         ManifestValidator.validate!(hash)
       end
       assert_match(/Expected array for key: addons but got: Hash/i, error.message)
+    end
+
+    def test_validate_addons_plan__required
+      hash = {
+        "addons" => [
+          {
+            "as": "string",
+            "options": {
+              "foo": "bar"
+            }
+          }
+        ]
+      }
+      error = assert_raises(AppManifest::InvalidManifest) do
+        ManifestValidator.validate!(hash)
+      end
+      assert_match(/Missing required key: plan/i, error.message)
+    end
+
+    def test_validate_addons_plan__nil
+      hash = {
+        "addons" => [
+          {
+            "plan": nil,
+            "as": "string",
+            "options": {
+              "foo": "bar"
+            }
+          }
+        ]
+      }
+      error = assert_raises(AppManifest::InvalidManifest) do
+        ManifestValidator.validate!(hash)
+      end
+      assert_match(/Missing required value for key: addons\[0\]\[plan\]/i, error.message)
     end
   end
 end

--- a/test/app_manifest/manifest_validator_test.rb
+++ b/test/app_manifest/manifest_validator_test.rb
@@ -83,21 +83,12 @@ module AppManifest
       end
     end
 
-    def test_validate_name__max_length_valid
+    def test_validate_name__valid_type
       hash = valid_manifest_hash
       hash["name"] = "a" * 30
       assert_silent do
         ManifestValidator.validate!(hash)
       end
-    end
-
-    def test_validate_name__max_length_exceeded
-      hash = valid_manifest_hash
-      hash["name"] = "a" * 31
-      error = assert_raises(AppManifest::InvalidManifest) do
-        ManifestValidator.validate!(hash)
-      end
-      assert_match(/String must not exceed 30 characters for key: name/i, error.message)
     end
 
     def test_validate_environment_manifest__valid

--- a/test/app_manifest/manifest_validator_test.rb
+++ b/test/app_manifest/manifest_validator_test.rb
@@ -1,0 +1,134 @@
+require 'test_helper'
+require 'support/environment_tests'
+
+module AppManifest
+  class ManifestValidatorTest < MiniTest::Test
+
+    def valid_manifest_hash
+      {
+        "name" => "Small Sharp Tool",
+        "description" => "This app does one little thing, and does it well.",
+        "keywords" => ["productivity", "HTML5", "scalpel"],
+        "website" => "https://small-sharp-tool.com/",
+        "repository" => "https://github.com/jane-doe/small-sharp-tool",
+        "logo" => "https://small-sharp-tool.com/logo.svg",
+        "success_url" => "/welcome",
+        "scripts" => {
+          "postdeploy" => "bundle exec rake bootstrap"
+        },
+        "env" => {
+          "SECRET_TOKEN" => {
+            "description" => "A secret key for verifying the integrity of signed cookies.",
+            "generator" => "secret"
+          },
+          "WEB_CONCURRENCY" => {
+            "description" => "The number of processes to run.",
+            "value" => "5"
+          }
+        },
+        "formation" => {
+          "web" => {
+            "quantity" => 1,
+            "size" => "standard-1x"
+          }
+        },
+        "image" => "heroku/ruby",
+        "addons" => [
+          "openredis",
+          {
+            "plan" => "mongolab:shared-single-small",
+            "as" => "MONGO"
+          },
+          {
+            "plan" => "heroku-postgresql",
+            "options" => {
+              "version" => "9.5"
+            }
+          }
+        ],
+        "buildpacks" => [
+          {
+            "url" => "https://github.com/stomita/heroku-buildpack-phantomjs"
+          }
+        ],
+        "environments" => {
+          "test" => {
+            "scripts" => {
+              "test" => "bundle exec rake test"
+            }
+          },
+          "review" => {
+            "addons" => [
+              "openredis",
+              {
+                "plan" => "mongolab:shared-single-small",
+                "as" => "MONGO"
+              },
+              {
+                "plan" => "heroku-postgresql",
+                "options" => {
+                  "version" => "9.5"
+                }
+              }
+            ]
+          },
+        }
+      }
+    end
+
+    def test_validate_manifest__valid
+      hash = valid_manifest_hash
+      assert_silent do
+        ManifestValidator.validate!(hash)
+      end
+    end
+
+    def test_validate_environment_manifest__valid
+      hash = {
+        "environments" => {
+          "test" => valid_manifest_hash,
+          "review" => valid_manifest_hash
+        }
+      }
+      assert_silent do
+        ManifestValidator.validate!(hash)
+      end
+    end
+
+    def test_validate_environment_name__invalid
+      hash = {
+        "environments" => {
+          "buildpack" => {}
+        }
+      }
+      error = assert_raises(AppManifest::InvalidManifest) do
+        ManifestValidator.validate!(hash)
+      end
+      assert_match(/Invalid environment name: buildpack/i, error.message)
+    end
+
+    def test_validate_environment_value__invalid_type
+      hash = {
+        "environments" => {
+          "test" => "foobar"
+        }
+      }
+      error = assert_raises(AppManifest::InvalidManifest) do
+        ManifestValidator.validate!(hash)
+      end
+      assert_match(/Expected object but got: String/i, error.message)
+    end
+
+    def test_validate_addons_value__invalid_type
+      hash = {
+        "addons" => {
+          "test" => "foobar"
+        }
+      }
+      error = assert_raises(AppManifest::InvalidManifest) do
+        ManifestValidator.validate!(hash)
+      end
+      assert_match(/Expected array for key: addons but got: Hash/i, error.message)
+    end
+  end
+end

--- a/test/support/environment_tests.rb
+++ b/test/support/environment_tests.rb
@@ -4,7 +4,7 @@ module AppManifest
       environment = environment_class.new(
         name: 'my-awesome-app',
         description: 'super duper awesome',
-        keywords: %w[awesome 9000]
+        keywords: ['awesome', 9000]
       )
 
       assert_equal(environment.name, 'my-awesome-app')

--- a/test/support/environment_tests.rb
+++ b/test/support/environment_tests.rb
@@ -4,7 +4,7 @@ module AppManifest
       environment = environment_class.new(
         name: 'my-awesome-app',
         description: 'super duper awesome',
-        keywords: ['awesome', 9000]
+        keywords: %w[awesome 9000]
       )
 
       assert_equal(environment.name, 'my-awesome-app')


### PR DESCRIPTION
Add a Manifest Validator module that performs some basic type checking based on the [app.json schema](https://devcenter.heroku.com/articles/app-json-schema).

This lib would now raise an error when passed an invalid manifest hash:
```
{
  "environments": {
    "review": {
    },
    "buildpacks": [
      {
        "url": "https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku-community/apt.tgz"
      }
    ]
  }
}
```
```
in `block in validate_environments': Invalid environment name: buildpacks (AppManifest::InvalidManifest)
```

- [W-9909381 - Improve Review App app.json parsing failures](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000007p2mwYAA/view)
- Fixes https://github.com/heroku/app-manifest/issues/5